### PR TITLE
Interlanguage conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Enabled for `.mscgen`, `.msc`, `.mscin`, `.xu`, and `.msgenny` files
     Xù with a simplified syntax. And a little less features. The
     [MsGenny wiki page](https://github.com/sverweij/mscgen_js/blob/master/wikum/msgenny.md)
     has more information.
+- Frictionless conversion MscGen/ Xù <=> MsGenny    
+  - Check the editor context menu for
+    - `MsGenny -> MscGen/ Xù`,
+    - `MscGen -> MsGenny` and
+    - `Xù -> MsGenny`
+  - or use `Mscgen Preview: Translate` in the command palette.
+
 
 ## License information
 This software is free software [licensed under GPL-3.0](LICENSE.md). This means (a.o.) you _can_ use

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,7 +37,7 @@ module.exports =
       'mscgen-preview:translate': =>
         @translate()
       'mscgen-preview:abstract-syntax-tree': =>
-        @translate('source.ast')
+        @translate('source.json')
       'mscgen-preview:auto-format': =>
         @autoFormat()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -114,7 +114,6 @@ module.exports =
       if error
         console.error error
       else
-        console.log result
         editor.setText(result)
 
   toggle: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,6 +36,8 @@ module.exports =
         @toggle()
       'mscgen-preview:translate': =>
         @translate()
+      'mscgen-preview:abstract-syntax-tree': =>
+        @translate('source.ast')
       'mscgen-preview:auto-format': =>
         @autoFormat()
 
@@ -77,7 +79,7 @@ module.exports =
 
     return editor
 
-  translate: ->
+  translate: (pScopeName)->
     return unless editor = @isActionable()
 
     autoTranslations =
@@ -85,7 +87,7 @@ module.exports =
       'source.xu'     : 'source.msgenny'
       'source.msgenny': 'source.xu'
 
-    toScope = autoTranslations[editor.getGrammar().scopeName] or 'source.xu'
+    toScope = pScopeName or autoTranslations[editor.getGrammar().scopeName] or 'source.xu'
 
     renderer ?= require "./renderer"
     renderer.translate editor.getText(), editor.getGrammar().scopeName, toScope, (error, result) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -117,7 +117,6 @@ module.exports =
         console.log result
         editor.setText(result)
 
-
   toggle: ->
     return unless editor = @isActionable()
     @addPreviewForEditor(editor) unless @removePreviewForEditor(editor)

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -4,7 +4,7 @@ scopeName2inputType  =
   'source.msgenny' : 'msgenny'
   'source.mscgen'  : 'mscgen'
   'source.xu'      : 'xu'
-  'source.ast'     : 'json'
+  'source.json'    : 'json'
 
 exports.scopeName2inputType = scopeName2inputType
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -1,12 +1,14 @@
 mscgenjs    = null # Defer until used
 
-scopeName2inputType =
-  'source.msgenny': 'msgenny'
-  'source.mscgen': 'mscgen'
-  'source.ast': 'json'
+scopeName2inputType  =
+  'source.msgenny' : 'msgenny'
+  'source.mscgen'  : 'mscgen'
+  'source.xu'      : 'xu'
+  'source.ast'     : 'json'
+
+exports.scopeName2inputType = scopeName2inputType
 
 exports.render = (pScript='', pElementId, pGrammar, pCallback) ->
-  # TODO: get dependencies from npm
   mscgenjs ?= require 'mscgenjs'
 
   lOptions =
@@ -14,3 +16,12 @@ exports.render = (pScript='', pElementId, pGrammar, pCallback) ->
     inputType: scopeName2inputType[pGrammar.scopeName] or 'xu'
 
   mscgenjs.renderMsc pScript, lOptions, pCallback
+
+exports.translate = (pScript='', pScopeFrom, pScopeTo, pCallback) ->
+  mscgenjs ?= require 'mscgenjs'
+
+  lOptions =
+    inputType: scopeName2inputType[pScopeFrom] or 'msgenny'
+    outputType: scopeName2inputType[pScopeTo] or 'xu'
+
+  mscgenjs.translateMsc pScript, lOptions, pCallback

--- a/menus/mscgen-preview.cson
+++ b/menus/mscgen-preview.cson
@@ -14,5 +14,17 @@
     {label: 'Save As SVG\u2026', command: 'core:save-as'}
     {label: 'Save As PNG\u2026', command: 'mscgen-preview:save-as-png'}
   ]
+  '.editor[data-grammar="source mscgen"]': [
+    {label: 'MscGen \u2192 MsGenny', command: 'mscgen-preview:translate'}
+    {label: 'MscGen - auto format', command: 'mscgen-preview:auto-format'}
+  ]
+  '.editor[data-grammar="source xu"]': [
+    {label: 'Xù \u2192 MsGenny', command: 'mscgen-preview:translate'}
+    {label: 'Xù - auto format', command: 'mscgen-preview:auto-format'}
+  ]
+  '.editor[data-grammar="source msgenny"]': [
+    {label: 'MsGenny \u2192 MscGen (/ Xù)', command: 'mscgen-preview:translate'}
+    {label: 'MsGenny - auto format', command: 'mscgen-preview:auto-format'}
+  ]
   # '.tree-view .file .name[data-name$=\\.mscgen]':
   #   [{label: 'MscGen Preview', command:  'mscgen-preview:preview-file'}]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-space-pen-views": "2.1.0",
     "fs-plus": "2.8.1",
     "underscore-plus": "1.6.6",
-    "mscgenjs": "1.2.5"
+    "mscgenjs": "1.2.7"
   },
   "devDependencies": {
     "coffeelint": "1.14.2",

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -294,6 +294,37 @@ describe "MscGen preview package", ->
           }
           """
           expect(mscEditor.getGrammar().scopeName).toBe "source.xu"
+      it "formats MscGen in the current buffer", ->
+        waitsForPromise -> atom.workspace.open()
+        runs ->
+          mscEditor = atom.workspace.getActiveTextEditor()
+          mscEditor.setGrammar(atom.grammars.grammarForScopeName("source.mscgen"))
+          mscEditor.setText """
+          /* just a sample */
+          msc {
+            a,b,c;
+            a =>b [label="label should be there",
+
+
+            textcolor="red", url="url won't be there"];
+            # comment that will disappear
+            b     >> a [label="spoken with truthiness"],b->c;
+          }
+          """
+          atom.commands.dispatch workspaceElement, 'mscgen-preview:auto-format'
+          expect(mscEditor.getText()).toBe """/* just a sample */
+          msc {
+            a,
+            b,
+            c;
+
+            a => b [label="label should be there", url="url won't be there", textcolor="red"];
+            b >> a [label="spoken with truthiness"],
+          b -> c;
+          }
+          """
+          expect(mscEditor.getGrammar().scopeName).toBe "source.mscgen"
+
     describe "when mscgen-preview:abstract-syntax-tree is triggered in an unassociated buffer", ->
       it "translates the current program into json and switches the grammar", ->
         waitsForPromise -> atom.workspace.open()

--- a/spec/mscgen-preview-view-spec.coffee
+++ b/spec/mscgen-preview-view-spec.coffee
@@ -1,7 +1,7 @@
-path = require 'path'
-fs = require 'fs-plus'
-temp = require 'temp'
-wrench = require 'wrench'
+path              = require 'path'
+fs                = require 'fs-plus'
+temp              = require 'temp'
+wrench            = require 'wrench'
 MscGenPreviewView = require '../lib/mscgen-preview-view'
 
 describe "MscGenPreviewView", ->


### PR DESCRIPTION
- Available as context menu commands:
  - mscgen-preview:translate - Translate Mscgen -> MsGenny, Xù -> MsGenny and MsGenny -> MscGen/ Xù. Fixes #9 
  - mscgen-preview:auto-format - Auto format (simply a languageX -> languageX translation). Fixes #7
- Not available as context menu command, but only with cmd-P
  - mscgen-preview:abstract-syntax-tree - translates to json
