### PR TITLE
removes workaround for https://github.com/mscgenjs/mscgenjs-core/issu…

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,10 +34,10 @@ module.exports =
     cannedStyleTemplate:
       title: 'Predefined styles'
       type: 'string'
-      default: ''
+      default: 'basic'
       order: 4
       description: '**Experimental!** Additional named styles to use for rendering the graphics. We\'d _love_ to hear your [feedback](https://github.com/sverweij/atom-mscgen-preview/issues/new?title=Feedback%20on%20\'predefined%20styles\':&body=...) on this feature.'
-      enum: [''].concat mscgenjs.getAllowedValues().namedStyle.map((pValue) -> pValue.name)
+      enum: mscgenjs.getAllowedValues().namedStyle.map((pValue) -> pValue.name)
 
   activate: ->
     atom.deserializers.add

--- a/lib/mscgen-preview-view.coffee
+++ b/lib/mscgen-preview-view.coffee
@@ -131,16 +131,10 @@ class MscGenPreviewView extends ScrollView
         @saveAs('png')
       'core:copy': (event) =>
         event.stopPropagation() if @copyToClipboard()
-      'mscgen-preview:style-none': (event) =>
+      'mscgen-preview:style-basic': (event) =>
         event.stopPropagation()
-        # workaround for mscgenjs/mscgenjs-core #26:
-        # first set a non-wobbly named style so renderMagic
-        # is straight again, and when that is done
-        # set the style to none/ ''
-        @setStyle('lazy')
-        @renderMsc().then =>
-          @setStyle('')
-          @renderMsc()
+        @setStyle('basic')
+        @renderMsc()
       'mscgen-preview:style-lazy': (event) =>
         event.stopPropagation()
         @setStyle('lazy')

--- a/menus/mscgen-preview.cson
+++ b/menus/mscgen-preview.cson
@@ -4,15 +4,6 @@
     'label': 'MscGen Preview'
     'submenu': [
       {'label': 'Toggle Preview', 'command': 'mscgen-preview:toggle'}
-      {
-        label: 'Select a style'
-        submenu: [
-          {label: 'none',               command:'mscgen-preview:style-none'}
-          {label: 'lazy',               command:'mscgen-preview:style-lazy'}
-          {label: 'classic',            command:'mscgen-preview:style-classic'}
-          {label: 'wobbly fountainpen', command:'mscgen-preview:style-fountainpen'}
-        ]
-      }
     ]
   ]
 ]
@@ -24,7 +15,7 @@
     {
       label: 'Style'
       submenu: [
-        {label: 'none',               command:'mscgen-preview:style-none'}
+        {label: 'basic',              command:'mscgen-preview:style-basic'}
         {label: 'lazy',               command:'mscgen-preview:style-lazy'}
         {label: 'classic',            command:'mscgen-preview:style-classic'}
         {label: 'wobbly fountainpen', command:'mscgen-preview:style-fountainpen'}


### PR DESCRIPTION
…es/26

- renames the 'none' style to basic
- removes the '' (empty) style from the list of styles
- makes 'basic' the default style

also
- removes the style switch option from the main menu - that only worked
  well when a preview window was (1) open and (2) had focus.